### PR TITLE
feat(tasks): add GET /tasks polling endpoint

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -92,6 +92,13 @@ export const listTasksForAgent = db.prepare<{ agent_id: string }, Task>(
   `SELECT * FROM tasks WHERE to_agent = @agent_id ORDER BY created_at DESC`
 );
 
+export const listTasksForAgentByStatus = db.prepare<
+  { agent_id: string; status: string },
+  Task
+>(
+  `SELECT * FROM tasks WHERE to_agent = @agent_id AND status = @status ORDER BY created_at DESC`
+);
+
 export const completeTask = db.prepare<{
   id: string;
   status: string;

--- a/src/routes/tasks.ts
+++ b/src/routes/tasks.ts
@@ -4,6 +4,8 @@ import {
   insertTask,
   getTask,
   getAgent,
+  listTasksForAgent,
+  listTasksForAgentByStatus,
   completeTask,
   touchAgent,
 } from "../db.js";
@@ -71,6 +73,52 @@ app.post("/", async (c) => {
   touchAgent.run({ id: auth.agentAddress });
 
   return c.json({ ok: true, task_id: taskId }, 201);
+});
+
+/**
+ * GET /tasks
+ * Poll for tasks assigned to the authenticated agent.
+ *
+ * For GET requests with no body, sign an empty string ("") as the message.
+ * Note: this signature is replayable — a timestamp nonce is recommended for v2.
+ *
+ * Query params:
+ *   ?status=pending|active|completed|failed   (optional, returns all if omitted)
+ *   ?to_agent=<stacks-address>                (optional, must match auth address if provided)
+ */
+app.get("/", (c) => {
+  const auth = extractAuth(c.req.raw.headers, "");
+  if (!auth.ok) {
+    return c.json({ error: auth.error }, 401);
+  }
+
+  const statusFilter = c.req.query("status");
+  const toAgentFilter = c.req.query("to_agent");
+
+  // If caller specifies to_agent, it must match the authenticated agent
+  if (toAgentFilter && toAgentFilter !== auth.agentAddress) {
+    return c.json(
+      { error: "to_agent must match the authenticated agent address" },
+      403
+    );
+  }
+
+  const tasks = statusFilter
+    ? listTasksForAgentByStatus.all({
+        agent_id: auth.agentAddress,
+        status: statusFilter,
+      })
+    : listTasksForAgent.all({ agent_id: auth.agentAddress });
+
+  touchAgent.run({ id: auth.agentAddress });
+
+  return c.json(
+    tasks.map((t) => ({
+      ...t,
+      payload: t.payload ? JSON.parse(t.payload) : null,
+      result: t.result ? JSON.parse(t.result) : null,
+    }))
+  );
 });
 
 /**


### PR DESCRIPTION
## Summary

Implements the task polling endpoint requested in #1.

- `GET /tasks` — returns all tasks assigned to the authenticated agent
- `GET /tasks?status=pending` — filter by status (pending|active|completed|failed)
- `GET /tasks?to_agent=<address>` — explicit address filter (must match auth)
- Touches `last_seen` on each poll
- Auth: sign an **empty string** (`""`) as the BIP-137 message for GET requests

## Auth note for GET requests

POST endpoints sign the JSON body — there's always a meaningful message. GET requests have no body, so agents sign `""`. This is consistent and simple, but the signature is replayable (same sig always valid). Flagging this for v2: a `X-Timestamp` header included in the signed message would prevent replay.

## Test plan

- [ ] Register an agent, submit a task to them
- [ ] `GET /tasks?status=pending` with valid BIP-137 headers → returns the task
- [ ] `GET /tasks?to_agent=<other-address>` → 403
- [ ] GET with invalid/missing headers → 401
- [ ] `GET /tasks?status=completed` after completing → task appears

Closes part of #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)