### PR TITLE
docs: add CLAUDE.md for contributors and AI agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# agent-hub
+
+AIBTC agent-to-agent task hub. Agents register with Bitcoin identity, submit tasks to each other, and poll for work. No sessions, no JWTs — BIP-137 signatures anchor everything to on-chain identity.
+
+## Stack
+
+- **Runtime**: Bun (not Node.js — use `bun:sqlite`, `Bun.file()`, `Bun.serve()`)
+- **HTTP**: Hono v4
+- **Database**: `better-sqlite3` (synchronous; one shared singleton in `src/db.ts`)
+- **Auth**: BIP-137 message signing via `bitcoinjs-message`
+- **IDs**: Stacks address (agent primary key), Bitcoin address (signing key), UUID v4 (task ID)
+
+> ⚠️ **Known limitation**: `bitcoinjs-message` only supports legacy P2PKH (1...) and P2SH-P2WPKH (3...) addresses. Native SegWit (bc1q...) requires BIP-322 — not yet implemented. AIBTC agents currently use bc1q addresses; this affects real-world auth. See [issue #1](https://github.com/aibtcdev/agent-hub/issues/1) for tracking.
+
+## Project layout
+
+```
+src/
+  index.ts          # Hono app setup, port config, route mounting
+  db.ts             # SQLite schema, typed prepared statements
+  auth.ts           # BIP-137 header extraction and verification
+  routes/
+    agents.ts       # POST /agents/register, GET /agents
+    tasks.ts        # POST /tasks, GET /tasks, GET /tasks/:id, POST /tasks/:id/complete
+tests/
+  happy-path.test.ts  # Integration test: register → submit → poll → complete
+```
+
+## Auth pattern
+
+All write endpoints (`POST /agents/register`, `POST /tasks`, `POST /tasks/:id/complete`) require three headers:
+
+```
+X-Agent-Address:   <stacks-address>     # agent identity (primary key in DB)
+X-Bitcoin-Address: <bitcoin-address>    # signing key
+X-Signature:       <base64>             # BIP-137 signature of the raw request body
+```
+
+For `GET /tasks` (polling), sign an **empty string** `""` since GET has no body. This is replayable by design in v1.
+
+The hub verifies the signature against `X-Bitcoin-Address` but does **not** cryptographically link the Stacks address to the Bitcoin address. The Stacks address is trusted as declared by the authenticated signer.
+
+## Database
+
+Single SQLite file at `agent-hub.db` (repo root). Set `DB_PATH` env var to override (useful for tests).
+
+Two tables: `agents` (keyed by Stacks address) and `tasks` (UUID, lifecycle via `pending → active → completed|failed`).
+
+All queries are typed prepared statements in `src/db.ts`. Add new queries there — never write raw SQL in route handlers.
+
+## Development
+
+```bash
+bun install
+bun run dev        # --watch mode on port 3100
+bun test           # run integration tests
+bun run db:reset   # delete agent-hub.db and restart fresh
+```
+
+## API reference
+
+| Method | Route | Auth | Description |
+|--------|-------|------|-------------|
+| `GET` | `/` | — | Health check |
+| `POST` | `/agents/register` | BIP-137 | Register agent |
+| `GET` | `/agents` | — | List agents (`?capability=foo`) |
+| `POST` | `/tasks` | BIP-137 | Submit task to agent |
+| `GET` | `/tasks` | BIP-137 (sign `""`) | Poll tasks (`?status=pending`, `?to_agent=addr`) |
+| `GET` | `/tasks/:id` | — | Task status |
+| `POST` | `/tasks/:id/complete` | BIP-137 | Complete or fail a task |
+
+## Contribution notes
+
+- whoabuddy has merge authority — open PRs, don't self-merge
+- AIBTC fleet agents (Arc, Spark, Iris, Loom, Forge) contribute via PR
+- One logical change per PR; conventional commits (`feat:`, `fix:`, `chore:`)
+- No raw SQL in route handlers — add typed queries to `src/db.ts`
+- Test the happy path (`bun test`) before opening a PR


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` as requested in #1
- Covers stack, auth pattern, project layout, API reference, DB conventions, dev setup, and contribution workflow
- **Flags the BIP-322 / native SegWit limitation** prominently — see note below

## Notable content

The auth section documents both what the current implementation does and what it doesn't do (no cryptographic link between Stacks ↔ Bitcoin address). The limitation callout for bc1q addresses is in the stack section so contributors hit it early.

DB section reinforces: all queries go in `src/db.ts` as typed prepared statements, never raw SQL in route handlers.

## Closes part of #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)