### PR TITLE
feat(tasks): add to_agent and from_agent directional filters to GET /tasks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ app.get("/", (c) =>
       "DELETE /agents/:name": "Remove an agent (requires API key)",
       "GET /capabilities": "List all capabilities, optionally filter by ?skill=name",
       "POST /tasks": "Submit a task to the hub (requires API key)",
-      "GET /tasks": "List submitted tasks, optionally filter by ?agent=name&status=pending",
+      "GET /tasks": "List submitted tasks, optionally filter by ?agent=name&to_agent=addr&from_agent=addr&status=pending",
       "PATCH /tasks/:id": "Update task status (requires API key)",
       "GET /health": "Fleet health summary",
     },
@@ -398,7 +398,9 @@ app.post("/tasks", async (c) => {
 
 // List tasks
 app.get("/tasks", async (c) => {
-  const agent = c.req.query("agent");
+  const agent = c.req.query("agent");       // matches from_agent OR to_agent
+  const toAgent = c.req.query("to_agent");   // tasks directed TO this agent
+  const fromAgent = c.req.query("from_agent"); // tasks sent FROM this agent
   const status = c.req.query("status");
   const limit = parseInt(c.req.query("limit") ?? "50", 10);
 
@@ -408,6 +410,14 @@ app.get("/tasks", async (c) => {
   if (agent) {
     query += " AND (from_agent = ? OR to_agent = ?)";
     binds.push(agent, agent);
+  }
+  if (toAgent) {
+    query += " AND to_agent = ?";
+    binds.push(toAgent);
+  }
+  if (fromAgent) {
+    query += " AND from_agent = ?";
+    binds.push(fromAgent);
   }
   if (status) {
     query += " AND status = ?";
@@ -473,7 +483,7 @@ app.get("/llms.txt", async (c) => {
     "POST /agents              - Register or update an agent",
     "GET  /capabilities?skill= - Find agents with a specific skill",
     "POST /tasks               - Submit a task to the hub",
-    "GET  /tasks               - List submitted tasks",
+    "GET  /tasks               - List submitted tasks (?agent=addr, ?to_agent=addr, ?from_agent=addr, ?status=pending)",
     "GET  /health              - Fleet health summary",
     "",
     "## Online Agents",


### PR DESCRIPTION
## Summary

Adds `?to_agent=` and `?from_agent=` query parameters to `GET /tasks`, enabling directional polling for agents.

- `?to_agent=<address>` — returns only tasks addressed **to** this agent (the main use case from issue #1)
- `?from_agent=<address>` — returns only tasks **sent by** this agent
- `?agent=<address>` — existing behavior preserved: matches either direction

These can be combined with `?status=pending` for clean inbox polling:
```
GET /tasks?to_agent=SP1092FF21MZXE9D7SZ7F86WA3Q58BY9WCZ0T0DF7&status=pending
```

Also updates the `GET /` endpoint index and `GET /llms.txt` discovery doc to document the new params.

## Changes

- `src/index.ts`: Added `toAgent` and `fromAgent` query param extraction and corresponding SQL clauses in `GET /tasks`; updated endpoint description strings in `/` and `/llms.txt`

## Test plan

- [ ] `GET /tasks?to_agent=<addr>` returns only tasks where `to_agent = addr`
- [ ] `GET /tasks?from_agent=<addr>` returns only tasks where `from_agent = addr`
- [ ] `GET /tasks?agent=<addr>` still matches both directions (unchanged behavior)
- [ ] Multiple params can be combined: `?to_agent=<addr>&status=pending`
- [ ] `bunx tsc --noEmit` passes with no errors

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)